### PR TITLE
fix reload status on householdoverview screen , ordered the task to be sorted when read from db and removed unnecessary reload event

### DIFF
--- a/apps/health_campaign_field_worker_app/lib/data/repositories/local/task.dart
+++ b/apps/health_campaign_field_worker_app/lib/data/repositories/local/task.dart
@@ -129,7 +129,13 @@ class TaskLocalRepository extends TaskLocalBaseRepository {
                   query.plannedStartDate!,
                   query.plannedEndDate!,
                 ),
-            ])))
+            ]))
+            ..orderBy([
+              OrderingTerm(
+                expression: sql.task.clientCreatedTime,
+                mode: OrderingMode.asc,
+              ),
+            ]))
           .get();
 
       final tasksMap = <String, TaskModel>{};

--- a/apps/health_campaign_field_worker_app/lib/widgets/member_card/member_card.dart
+++ b/apps/health_campaign_field_worker_app/lib/widgets/member_card/member_card.dart
@@ -302,20 +302,11 @@ class MemberCard extends StatelessWidget {
                                       final bloc =
                                           context.read<HouseholdOverviewBloc>();
                                       bloc.add(
-                                        HouseholdOverviewReloadEvent(
-                                          projectId: context.projectId,
-                                          projectBeneficiaryType:
-                                              beneficiaryType,
-                                        ),
-                                      );
-                                      bloc.add(
                                         HouseholdOverviewEvent
                                             .selectedIndividual(
                                           individualModel: individual,
                                         ),
                                       );
-
-                                      // todo: verify this
 
                                       if ((tasks ?? []).isEmpty) {
                                         context.router.push(


### PR DESCRIPTION
fix reload status on householdoverview screen , ordered the task to be sorted when read from db and removed unnecessary reload event