### PR TITLE
TICKET:2498,2499

### DIFF
--- a/apps/health_campaign_field_worker_app/lib/pages/beneficiary_registration/individual_details.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/beneficiary_registration/individual_details.dart
@@ -56,8 +56,9 @@ class _IndividualDetailsPageState
 
   final ValueNotifier<String> heightWeight = ValueNotifier("");
 
-  void updateStatus(dynamic age) {
+  void updateStatus(FormGroup form, dynamic age) {
     // Updating the ValueNotifier
+
     if (age == null) {
       if (heightWeight.value != "") {
         heightWeight.value = ""; // Only update if necessary
@@ -66,6 +67,12 @@ class _IndividualDetailsPageState
       final cat = getCategory(getAgeMonths(age));
       final newValue =
           (cat == Constants.height || cat == Constants.weight) ? cat : "";
+
+      if (newValue == Constants.height) {
+        form.control(_weight).value = "";
+      } else if (newValue == Constants.weight) {
+        form.control(_height).value = "";
+      }
 
       if (heightWeight.value != newValue) {
         heightWeight.value = newValue; // Update only if changed
@@ -499,12 +506,13 @@ class _IndividualDetailsPageState
                               // Handle changes to the control's value here
                               final value = formControl.value;
                               if (value == null) {
-                                updateStatus(null);
+                                updateStatus(form, null);
                                 formControl.setErrors({'': true});
                               } else {
                                 DigitDOBAge age =
                                     DigitDateUtils.calculateAge(value);
-                                updateStatus(age);
+
+                                updateStatus(form, age);
                                 if ((age.years == 0 && age.months == 0) ||
                                     age.months > 11 ||
                                     (age.years > 150 ||
@@ -557,17 +565,25 @@ class _IndividualDetailsPageState
                                 // weight
                                 if (isVisible == Constants.weight) {
                                   return DigitTextFormField(
+                                    inputFormatters: [
+                                      //FilteringTextInputFormatter.digitsOnly,
+                                      FilteringTextInputFormatter.allow(
+                                          RegExp(r'^\d*\.?\d{0,2}'),),
+                                    ],
                                     formControlName: _weight,
                                     label: localizations.translate(
                                       i18.individualDetails.weightHeadLabelText,
                                     ),
-                                    isRequired: (isVisible == Constants.weight ||
+                                    isRequired: (isVisible ==
+                                                Constants.weight ||
                                             (individual != null &&
                                                 getCategory(getAgeMonths(
-                                                      DigitDateUtils.calculateAge(
+                                                      DigitDateUtils
+                                                          .calculateAge(
                                                         DateFormat('dd/MM/yyyy')
                                                             .parse(
-                                                          individual.dateOfBirth!,
+                                                          individual
+                                                              .dateOfBirth!,
                                                         ),
                                                       ),
                                                     )) ==
@@ -577,17 +593,23 @@ class _IndividualDetailsPageState
                                   );
                                 } else if (isVisible == Constants.height) {
                                   return DigitTextFormField(
+                                    inputFormatters: [
+                                      FilteringTextInputFormatter.digitsOnly,
+                                    ],
                                     formControlName: _height,
                                     label: localizations.translate(
                                       i18.individualDetails.heightHeadLabelText,
                                     ),
-                                    isRequired: (isVisible == Constants.height ||
+                                    isRequired: (isVisible ==
+                                                Constants.height ||
                                             (individual != null &&
                                                 getCategory(getAgeMonths(
-                                                      DigitDateUtils.calculateAge(
+                                                      DigitDateUtils
+                                                          .calculateAge(
                                                         DateFormat('dd/MM/yyyy')
                                                             .parse(
-                                                          individual.dateOfBirth!,
+                                                          individual
+                                                              .dateOfBirth!,
                                                         ),
                                                       ),
                                                     )) ==
@@ -605,17 +627,25 @@ class _IndividualDetailsPageState
                                         )) ==
                                         Constants.weight)) {
                                   return DigitTextFormField(
+                                    inputFormatters: [
+                                      // FilteringTextInputFormatter.digitsOnly,
+                                      FilteringTextInputFormatter.allow(
+                                          RegExp(r'^\d*\.?\d{0,2}'),),
+                                    ],
                                     formControlName: _weight,
                                     label: localizations.translate(
                                       i18.individualDetails.weightHeadLabelText,
                                     ),
-                                    isRequired: (isVisible == Constants.weight ||
+                                    isRequired: (isVisible ==
+                                                Constants.weight ||
                                             (individual != null &&
                                                 getCategory(getAgeMonths(
-                                                      DigitDateUtils.calculateAge(
+                                                      DigitDateUtils
+                                                          .calculateAge(
                                                         DateFormat('dd/MM/yyyy')
                                                             .parse(
-                                                          individual.dateOfBirth!,
+                                                          individual
+                                                              .dateOfBirth!,
                                                         ),
                                                       ),
                                                     )) ==
@@ -633,17 +663,23 @@ class _IndividualDetailsPageState
                                         )) ==
                                         Constants.height)) {
                                   return DigitTextFormField(
+                                    inputFormatters: [
+                                      FilteringTextInputFormatter.digitsOnly,
+                                    ],
                                     formControlName: _height,
                                     label: localizations.translate(
                                       i18.individualDetails.heightHeadLabelText,
                                     ),
-                                    isRequired: (isVisible == Constants.height ||
+                                    isRequired: (isVisible ==
+                                                Constants.height ||
                                             (individual != null &&
                                                 getCategory(getAgeMonths(
-                                                      DigitDateUtils.calculateAge(
+                                                      DigitDateUtils
+                                                          .calculateAge(
                                                         DateFormat('dd/MM/yyyy')
                                                             .parse(
-                                                          individual.dateOfBirth!,
+                                                          individual
+                                                              .dateOfBirth!,
                                                         ),
                                                       ),
                                                     )) ==

--- a/apps/health_campaign_field_worker_app/lib/utils/utils.dart
+++ b/apps/health_campaign_field_worker_app/lib/utils/utils.dart
@@ -638,28 +638,64 @@ DoseCriteriaModel? fetchProductVariant(
 
 String convertToRange(String? condition1, String? condition2) {
   // Function to extract the number from a condition
-  int extractNumber(String? condition, int defaultValue) {
+  double extractNumber(String? condition, double defaultValue) {
     if (condition == null || condition.isEmpty) {
       return defaultValue; // Return default if condition is null or empty
     }
-    final RegExp regExp = RegExp(r'\d+');
+    final RegExp regExp =
+        RegExp(r'\d+(\.\d+)?'); // Support integers and decimals
     final match = regExp.firstMatch(condition);
 
-    return match != null ? int.parse(match.group(0)!) : defaultValue;
+    return match != null ? double.parse(match.group(0)!) : defaultValue;
   }
 
-  // Handle default values for condition1 and condition2
-  int num1 = extractNumber(condition1, 0); // Default to 0 for condition1
-  if (condition2 == null || condition2.isEmpty) {
-    return ""; // Return empty string if condition2 is null or empty
+  // Determine the adjustment factors based on the condition type
+  double adjustNumber(String condition, double number, bool isNum1) {
+    if (condition.contains("age") || condition.contains("height")) {
+      return isNum1 ? number + 1 : number - 1; // Adjust for age and height
+    } else if (condition.contains("weight")) {
+      return isNum1 ? number + 0.1 : number - 0.1; // Adjust decimals for weight
+    }
+
+    return number; // No adjustment for other conditions
   }
-  int num2 = extractNumber(condition2, 0);
+
+  // Format the number for weight to preserve `.0`
+  String formatNumberForWeight(double number) {
+    return number.toStringAsFixed(1); // Keep one decimal place for weight
+  }
+
+  // Format the number for other conditions
+  String formatNumber(double number) {
+    if (number == number.toInt()) {
+      return number.toInt().toString(); // Return as integer if no decimal part
+    }
+
+    return number.toString(); // Return as is for decimals
+  }
+
+  // Extract numbers from conditions
+  double num1 = extractNumber(condition1, 0);
+  double num2 = extractNumber(condition2, 0);
+
+  // Apply adjustments based on the condition type
+  if (condition1 != null) {
+    num1 = adjustNumber(condition1, num1, true);
+  }
+  if (condition2 != null) {
+    num2 = adjustNumber(condition2, num2, false);
+  }
 
   // Sort the numbers to ensure the smaller number is on the left
-  List<int> numbers = [num1, num2]..sort();
+  List<double> numbers = [num1, num2]..sort();
 
-  // Return the range in "small-big" format
-  return "${numbers[0]}-${numbers[1]}";
+  // Format the output based on the condition type
+  if ((condition1?.contains("weight") ?? false) ||
+      (condition2?.contains("weight") ?? false)) {
+    return "${formatNumberForWeight(numbers[0])}-${formatNumberForWeight(numbers[1])}";
+  }
+
+  return "${formatNumber(numbers[0])}-${formatNumber(numbers[1])}";
 }
 
 Future<bool> getIsConnected() async {


### PR DESCRIPTION
1. height and weight fields accepting alphabets during data entry
2. While registering a child, entering height as 49 shows "Not Eligible." However, during administration,  while administering  another child with 50cm height the pop-up says the height range is 49-55 cm.

When a child is created with a height of 54 cm, the resource pop-up shows "2ml for 49-55 cm." For another child with a height of 56 cm, the pop-up shows "4ml for 54-66 cm." The height range of 54-55 cm is being shown as common for both children.

 beneficiary age displaying incorrect in resource pop-up

In ticket comments mention that height and weight for the household head should not be displayed, but in the APK, these fields are still appearing.

When a child is created using the weight criteria based on age and later edited to switch to the height criteria, the height field should appear. However, currently, only the weight field is visible.